### PR TITLE
Merchant item update 33

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 class ApplicationController < ActionController::Base
  def set_merchant
-    @merchant = Merchant.find(params[:id])
+    @merchant = Merchant.find(params[:merchant_id])
   end
 
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
 
-  before_action :set_merchant, except: [:update, :destroy]
+  before_action :set_merchant#, except: [:update, :destroy]
 
   def index
     @items = @merchant.items
@@ -8,6 +8,26 @@ class ItemsController < ApplicationController
 
   def show
     @item = @merchant.items.find(params[:item_id])
+  end
+
+  def edit
+    @item = @merchant.items.find(params[:item_id])
+  end
+
+  def update
+    item = Item.find(params[:item_id])
+    if item.update(item_prams)
+      item.update(item_prams)
+      redirect_to "/merchants/#{@merchant.id}/items/#{item.id}"
+    else 
+      redirect_to "/merchants/#{@merchant.id}/items/#{item.id}/edit"
+      flash[:alert] = "Error: all required fields must be filled!}"
+    end
+  end
+
+private
+  def item_prams
+    params.permit(:id, :name, :description, :unit_price)
   end
 
 end

--- a/app/controllers/merchants_controller.rb
+++ b/app/controllers/merchants_controller.rb
@@ -1,7 +1,7 @@
 class MerchantsController < ApplicationController
 
 	def show
-		@merchant = Merchant.find(params[:id])
+		@merchant = Merchant.find(params[:merchant_id])
 	end
 
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,7 +1,7 @@
 class Item < ApplicationRecord
 	has_many :invoice_items
 	belongs_to	:merchant 
-    has_many :invoices, through: :invoice_items
+  has_many :invoices, through: :invoice_items
 
   
   validates_presence_of :name, :description, :unit_price

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -1,12 +1,11 @@
 class Merchant < ApplicationRecord
   has_many :items
-  validates_presence_of(:name)
-  
   has_many :invoice_items, through: :items
   has_many :invoices, through: :invoice_items
   has_many :customers, through: :invoices, source: :invoice_items
   has_many :transactions, through: :invoices
 
+  validates_presence_of(:name)
 
   def items_ready_to_ship
     InvoiceItem.where(item: items).where.not(status: 2)

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -2,7 +2,6 @@ class Transaction < ApplicationRecord
   belongs_to :invoice
 
   validates_presence_of :credit_card_number
-  # validates_presence_of :credit_card_expiration_date
   validates_presence_of :result
 
   enum result: {"success" => 0, "failed" => 1}

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,0 +1,11 @@
+<h1>Edit Item</h1>
+
+<%= form_with url: "/merchants/#{@merchant.id}/items/#{@item.id}", method: :patch, local: true do |f| %>
+  <%= f.label :name %>
+  <%= f.text_field :name %>
+  <%= f.label :description %>
+  <%= f.text_field :description %>
+  <%= f.label :unit_price %>
+  <%= f.text_field :unit_price %>
+  <%= f.submit %>
+<% end %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,3 +1,6 @@
 <h4><%= @item.name %></h4>
 <p>Description: <%= @item.description %></p>
 <p>Selling Price: $<%= @item.selling_price %></p>
+
+
+<%= link_to 'Edit Item', "/merchants/#{@merchant.id}/items/#{@item.id}/edit" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,11 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
-  get 'merchants/:id/dashboard', to: 'merchants#show'
-  get 'merchants/:id/items', to: 'items#index'
-  get 'merchants/:id/items/:item_id', to: 'items#show'
-  get 'merchants/:id/items/:item_id/edit', to: 'items#edit'
+  get 'merchants/:merchant_id/dashboard', to: 'merchants#show'
+  get 'merchants/:merchant_id/items', to: 'items#index'
+  get 'merchants/:merchant_id/items/:item_id', to: 'items#show'
+  get 'merchants/:merchant_id/items/:item_id/edit', to: 'items#edit'
   patch 'merchants/:merchant_id/items/:item_id', to: 'items#update'
-  get 'merchants/:id/invoices', to: 'invoices#index'
+  get 'merchants/:merchant_id/invoices', to: 'invoices#index'
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,8 @@ Rails.application.routes.draw do
   get 'merchants/:id/dashboard', to: 'merchants#show'
   get 'merchants/:id/items', to: 'items#index'
   get 'merchants/:id/items/:item_id', to: 'items#show'
+  get 'merchants/:id/items/:item_id/edit', to: 'items#edit'
+  patch 'merchants/:merchant_id/items/:item_id', to: 'items#update'
   get 'merchants/:id/invoices', to: 'invoices#index'
+
 end

--- a/spec/features/merchants/items/show_spec.rb
+++ b/spec/features/merchants/items/show_spec.rb
@@ -21,4 +21,25 @@ RSpec.describe 'merchants items show page', type: :feature do
     expect(page).not_to have_content(@item4.name)
     expect(page).not_to have_content(@item5.selling_price)
   end
+
+  xit 'shows a link to update item info' do 
+    visit "/merchants/#{@merchant1.id}/items/#{@item1.id}"
+   
+    click_link "Edit Item"
+
+    expect(current_path).to eq("/merchants/#{@merchant1.id}/items/#{@item1.id}/edit")
+
+    fill_in 'Name', with: 'New Item'
+    fill_in 'Description', with: 'New Item description'
+    fill_in 'Unit price', with: '10000'
+
+    click_button 'Save'
+    updated_item = Item.find(@item1.id)
+    expect(current_path).to eq("/merchants/#{@merchant1.id}/items/#{updated_item.id}")
+    expect(page).to have_content('New Item description')
+    expect(page).to have_content('New Item')
+    expect(page).to have_content(100.00)
+  end
+
+
 end

--- a/spec/features/merchants/items/show_spec.rb
+++ b/spec/features/merchants/items/show_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'merchants items show page', type: :feature do
     expect(page).not_to have_content(@item5.selling_price)
   end
 
-  xit 'shows a link to update item info' do 
+  it 'shows a link to update item info' do 
     visit "/merchants/#{@merchant1.id}/items/#{@item1.id}"
    
     click_link "Edit Item"
@@ -40,6 +40,5 @@ RSpec.describe 'merchants items show page', type: :feature do
     expect(page).to have_content('New Item')
     expect(page).to have_content(100.00)
   end
-
 
 end


### PR DESCRIPTION
As a merchant,
When I visit the merchant show page of an item
I see a link to update the item information.
When I click the link
Then I am taken to a page to edit this item
And I see a form filled in with the existing item attribute information
When I update the information in the form and I click ‘submit’
Then I am redirected back to the item show page where I see the updated information
And I see a flash message stating that the information has been successfully updated.