### PR TITLE
item index page groups items by status

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -13,4 +13,12 @@ class Item < ApplicationRecord
         BigDecimal(unit_price.to_f/100, 5)
     end
 
+    def self.enabled_items
+      where(status: 'enabled')
+    end
+
+    def self.disabled_items
+      where(status: 'disabled')
+   end
+
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,15 +1,26 @@
 <h1> <%= @merchant.name %></h1>
 <h3> Items </h3>
 
-<% @items.each do |item| %>
-<section id = "item-<%= item.id %>">
-<p> <%= link_to item.name, "/merchants/#{@merchant.id}/items/#{item.id}" %> </p>
-	<p>Status: <%= item.status %>
-	<% if item.status == 'enabled' %>
-		<%= button_to "Disable Item", "/merchants/#{@merchant.id}/items/#{item.id}", method: :patch, params: {:item_id => item.id, :merchant_id => @merchant.id, :status => 'disabled'}%>
-	<% elsif item.status == 'disabled' %>
-		<%= button_to "Enable Item", "/merchants/#{@merchant.id}/items/#{item.id}", method: :patch, params: {:item_id => item.id, :merchant_id => @merchant.id, :status => 'enabled'}%>
+<section id = 'enabled_items'>
+	<h1>Enabled Items</h1>
+	<% @items.enabled_items.each do |item| %>
+		<section id = "item-<%= item.id %>">
+			<p> <%= link_to item.name, "/merchants/#{@merchant.id}/items/#{item.id}" %> </p>
+			<p>Status: <%= item.status %>
+			<%= button_to "Disable Item", "/merchants/#{@merchant.id}/items/#{item.id}", method: :patch, params: {:item_id => item.id, :merchant_id => @merchant.id, :status => 'disabled'}%></p>
+		</section>
 	<% end %>
-</p>
 </section>
-<% end %>
+
+
+<section id = 'disabled_items'>
+	<h1>Disabled Items</h1>
+	<% @items.disabled_items.each do |item| %>
+		<section id = "item-<%= item.id %>">
+			<p> <%= link_to item.name, "/merchants/#{@merchant.id}/items/#{item.id}" %> </p>
+			<p>Status: <%= item.status %>
+			<%= button_to "Enable Item", "/merchants/#{@merchant.id}/items/#{item.id}", method: :patch, params: {:item_id => item.id, :merchant_id => @merchant.id, :status => 'enabled'}%></p>
+		</section>
+	<% end %>
+</section>
+

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -40,4 +40,37 @@ RSpec.describe 'merchants items index page', type: :feature do
       expect(page).to have_content("Status: enabled")
     end
   end
+
+  it 'groups merchants by status' do 
+    visit "/merchants/#{@merchant1.id}/items"
+
+    within('#enabled_items') do 
+      expect(page).to have_content(@item1.name)
+      expect(page).to have_content(@item2.name)
+      expect(page).to have_content(@item3.name)
+    end
+
+    within('#disabled_items') do 
+      expect(page).to_not have_content(@item1.name)
+      expect(page).to_not have_content(@item2.name)
+      expect(page).to_not have_content(@item3.name)
+    end
+
+    within("#item-#{@item1.id}") do 
+      click_button 'Disable Item'
+    end
+
+     within('#enabled_items') do 
+      expect(page).to_not have_content(@item1.name)
+      expect(page).to have_content(@item2.name)
+      expect(page).to have_content(@item3.name)
+    end
+
+     within('#disabled_items') do 
+      expect(page).to have_content(@item1.name)
+      expect(page).to_not have_content(@item2.name)
+      expect(page).to_not have_content(@item3.name)
+    end
+
+  end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -17,6 +17,26 @@ RSpec.describe Item, type: :model do
       let!(:status) { %i[disabled enabled] }
   end
 
+  describe 'class methods' do 
+    before :each do 
+    @merchant1 = Merchant.create!(name: "Schroeder-Jerde")
+    @item1 = @merchant1.items.create!(name: "Item Qui Esse", description: "Nihil autem sit odio inventore deleniti. Est lauda...", unit_price: 75107)
+    @item2 = @merchant1.items.create!(name: "Item Autem Minima", description: "Cumque consequuntur ad. Fuga tenetur illo molestia...", unit_price: 67076)
+    @item3 = @merchant1.items.create!(name: "Item Ea Voluptatum", description: "Sunt officia eum qui molestiae. Nesciunt quidem cu...", unit_price: 32301)
+    @item4 = @merchant1.items.create!(name: "Yabba Dabba", description: "Eat your vitamins", unit_price: 30000, status: 'disabled')
+    end
+    describe '#enabled_items' do 
+      it 'returns all items with enabled status' do 
+        expect(@merchant1.items.enabled_items).to eq([@item1, @item2, @item3])
+      end
+    end
+
+      describe '#disabled_items' do 
+      it 'returns all items with disabled status' do 
+        expect(@merchant1.items.disabled_items).to eq([@item4])
+      end
+    end
+  end
 
   describe 'instance methods' do 
 


### PR DESCRIPTION
As a merchant,
When I visit my merchant items index page
Then I see two sections, one for "Enabled Items" and one for "Disabled Items"
And I see that each Item is listed in the appropriate section