### PR TITLE
merchant items index page has link to add new item

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -10,6 +10,14 @@ class ItemsController < ApplicationController
     @item = @merchant.items.find(params[:item_id])
   end
 
+  def new
+  end
+
+  def create
+    item = @merchant.items.create(item_params)
+    redirect_to "/merchants/#{@merchant.id}/items"
+  end
+
   def edit
     @item = @merchant.items.find(params[:item_id])
   end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,11 +1,11 @@
 <h1>Edit Item</h1>
 
 <%= form_with url: "/merchants/#{@merchant.id}/items/#{@item.id}", method: :patch, local: true do |f| %>
-  <%= f.label :name %>
-  <%= f.text_field :name %>
-  <%= f.label :description %>
-  <%= f.text_field :description %>
-  <%= f.label :unit_price %>
-  <%= f.text_field :unit_price %>
+  <p><%= f.label :name %></p>
+  <p><%= f.text_field :name %></p>
+  <p><%= f.label :description %></p>
+  <p><%= f.text_field :description %></p>
+  <p><%= f.label :unit_price %></p>
+  <p><%= f.text_field :unit_price %></p>
   <%= f.submit %>
 <% end %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,4 +1,5 @@
 <h1> <%= @merchant.name %></h1>
+<h4><%= link_to 'Add New Item', "/merchants/#{@merchant.id}/items/new" %></h4>
 <h3> Items </h3>
 
 <section id = 'enabled_items'>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -1,0 +1,11 @@
+<h1>New Item</h1>
+
+<%= form_with url: "/merchants/#{@merchant.id}/items", method: :post, local: true do |f| %>
+  <p><%= f.label :name %></p>
+  <p><%= f.text_field :name %></p>
+  <p><%= f.label :description %></p>
+  <p><%= f.text_field :description %></p>
+  <p><%= f.label :time_balance, "Unit Price in Cents" %></p>
+  <p><%= f.text_field :unit_price %></p>
+  <p><%= f.submit 'Submit'%></p>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,8 @@ Rails.application.routes.draw do
 
   get 'merchants/:merchant_id/dashboard', to: 'merchants#show'
   get 'merchants/:merchant_id/items', to: 'items#index'
+  get 'merchants/:merchant_id/items/new', to: 'items#new'
+  post 'merchants/:merchant_id/items', to: 'items#create'
   get 'merchants/:merchant_id/items/:item_id', to: 'items#show'
   get 'merchants/:merchant_id/items/:item_id/edit', to: 'items#edit'
   patch 'merchants/:merchant_id/items/:item_id', to: 'items#update'

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -71,6 +71,24 @@ RSpec.describe 'merchants items index page', type: :feature do
       expect(page).to_not have_content(@item2.name)
       expect(page).to_not have_content(@item3.name)
     end
+  end
 
+
+  it 'has a link to ucreate a new item' do 
+    visit "/merchants/#{@merchant1.id}/items"
+
+    expect(page).to_not have_content('Dog Sweater')
+
+    click_link 'Add New Item'
+
+    expect(current_path).to eq("/merchants/#{@merchant1.id}/items/new")
+
+    fill_in 'Name', with: 'Dog Sweater'
+    fill_in 'Description', with: 'Perfect for small to large dogs.'
+    fill_in 'unit_price', with: 1399
+    click_button 'Submit'
+
+    expect(current_path).to eq("/merchants/#{@merchant1.id}/items")
+    expect(page).to have_content('Dog Sweater')
   end
 end


### PR DESCRIPTION
As a merchant
When I visit my items index page
I see a link to create a new item.
When I click on the link,
I am taken to a form that allows me to add item information.
When I fill out the form I click ‘Submit’
Then I am taken back to the items index page
And I see the item I just created displayed in the list of items.
And I see my item was created with a default status of disabled.